### PR TITLE
ARCSPC1201 - brought in subject headings from core to Collection Overview

### DIFF
--- a/public/views/shared/_record_innards.html.erb
+++ b/public/views/shared/_record_innards.html.erb
@@ -69,15 +69,15 @@
 	<%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('resource._public.additional'),
 	      :p_id => 'add_desc', :p_body => x } %>
 	<% end %>
-        <% if @result.kind_of?(Accession) && !@result.deaccessions.blank? %>
-          <% x = render partial: 'shared/present_list', locals: {:list =>  @result.deaccessions.collect{|d| d.fetch('description')}, :list_clss => 'deaccessions'} %>
-          <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('deaccessions'), :p_id => 'deaccessions_list', :p_body => x} %>
-        <% end %>
-        <% unless @result.subjects.blank? %>
-	   <% x= render partial: 'shared/present_list', locals: {:list => @result.subjects, :list_clss => 'subjects_list'} %>
-	   <%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('subject._plural'),
-	      :p_id => 'subj_list', :p_body => x} %>
-	<% end %>
+    <% if @result.kind_of?(Accession) && !@result.deaccessions.blank? %>
+      <% x = render partial: 'shared/present_list', locals: {:list =>  @result.deaccessions.collect{|d| d.fetch('description')}, :list_clss => 'deaccessions'} %>
+      <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('deaccessions'), :p_id => 'deaccessions_list', :p_body => x} %>
+    <% end %>
+    <% unless @result.subjects.blank? %>
+      <% x= render partial: 'shared/subjects_list', locals: {:list => @result.subjects} %>
+      <%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('subject._plural'),
+        :p_id => 'subj_list', :p_body => x} %>
+    <% end %>
   <% unless @result.classifications.blank? %>
     <% x= render partial: 'classifications/related_listing', locals: {:classifications => @result.classifications} %>
     <%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('classification._plural'),


### PR DESCRIPTION
Requested subject-heading functionality has been brought in from core PUI into our pui template.

Example running on dev:
https://aspacepui-dev.lib.harvard.edu/repositories/24/resources/10142